### PR TITLE
Add syntax checking to vim

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,12 @@ curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim
 # Install airline status bar
 git clone https://github.com/vim-airline/vim-airline ~/.vim/bundle/vim-airline
 
+# Install ansible vim plugin
+git clone https://github.com/pearofducks/ansible-vim.git ~/.vim/bundle/ansible-vim
+
+# Install syntastic syntax checker
+git clone https://github.com/vim-syntastic/syntastic.git ~/.vim/bundle/syntastic
+
 # Check for existing ~/.vimrc and back it up if it exists
 if [ -f $HOME/.vimrc ]; then
     echo

--- a/vimrc
+++ b/vimrc
@@ -116,6 +116,27 @@ set smartcase
 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 "                                                                              "
+"                              Syntax Checking                                 "
+"                                                                              "
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+set statusline+=%#warningmsg#
+set statusline+=%{SyntasticStatuslineFlag()}
+set statusline+=%*
+
+let g:syntastic_always_populate_loc_list = 1
+let g:syntastic_auto_loc_list = 1
+let g:syntastic_check_on_open = 1
+let g:sytastic_check_on_wq = 0
+
+let g:syntastic_ansible_checkers = ['ansible-lint']
+let g:syntastic_markdown_checkers = ['textlint']
+let g:syntastic_markdown_textlint_args = "--rule no-todo,no-empty-section,common-misspellings,alex,rousseau"
+let g:syntastic_yaml_checkers = ['yamllint']
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+"                                                                              "
 "                            Text Formatting                                   "
 "                                                                              "
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
Added syntastic and ansible-vim plugins.

**NOTE:** The syntastic configuration assumes the following are
installed:
* ansible-lint
* textlint; with the following rules
  * no-todo
  * no-empty-section
  * common-misspellings
  * alex
  * rousseau
* yamllint

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>