### PR TITLE
Small fixes to vimrc and vim related install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,18 +24,16 @@ pip install -r /tmp/requirements.txt
 rm /tmp/requirements.txt
 
 # Install pathogen for vim plugin management
-mkdir -p "$HOME"/.vim/autoload "$HOME"/.vim/bundle
-curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim
-
-# Install airline status bar
-if [[ -d "$HOME"/.vim/bundle/vim-airline ]]; then
-    pushd "$HOME"/.vim/bundle/vim-airline
+mkdir -p "$HOME"/.vim/bundle
+if [[ -d "$HOME"/.vim/vim-pathogen ]]; then
+    pushd "$HOME"/.vim/vim-pathogen
     git checkout master
     git fetch
     git reset --hard origin/master
 else
-    git clone https://github.com/vim-airline/vim-airline ~/.vim/bundle/vim-airline
+    git clone git@github.com:tpope/vim-pathogen.git "$HOME"/.vim/vim-pathogen
 fi
+ln -sf "$HOME"/.vim/vim-pathogen/autoload "$HOME"/.vim/autoload
 
 # Install ansible vim plugin
 if [[ -d "$HOME"/.vim/bundle/ansible-vim ]]; then
@@ -44,7 +42,7 @@ if [[ -d "$HOME"/.vim/bundle/ansible-vim ]]; then
     git fetch
     git reset --hard origin/master
 else
-    git clone https://github.com/pearofducks/ansible-vim.git ~/.vim/bundle/ansible-vim
+    git clone https://github.com/pearofducks/ansible-vim.git "$HOME"/.vim/bundle/ansible-vim
 fi
 
 # Install syntastic syntax checker
@@ -54,7 +52,17 @@ if [[ -d "$HOME"/.vim/bundle/syntastic ]]; then
     git fetch
     git reset --hard origin/master
 else
-    git clone https://github.com/vim-syntastic/syntastic.git ~/.vim/bundle/syntastic
+    git clone https://github.com/vim-syntastic/syntastic.git "$HOME"/.vim/bundle/syntastic
+fi
+
+# Install vim airline status bar
+if [[ -d "$HOME"/.vim/bundle/vim-airline ]]; then
+    pushd "$HOME"/.vim/bundle/vim-airline
+    git checkout master
+    git fetch
+    git reset --hard origin/master
+else
+    git clone https://github.com/vim-airline/vim-airline "$HOME"/.vim/bundle/vim-airline
 fi
 
 # Check for existing ~/.vimrc and back it up if it exists

--- a/vimrc
+++ b/vimrc
@@ -144,7 +144,7 @@ set statusline+=%*
 let g:syntastic_always_populate_loc_list = 1
 let g:syntastic_auto_loc_list = 1
 let g:syntastic_check_on_open = 1
-let g:sytastic_check_on_wq = 0
+let g:syntastic_check_on_wq = 0
 
 let g:syntastic_ansible_checkers = ['ansible-lint']
 let g:syntastic_markdown_checkers = ['textlint']
@@ -190,6 +190,7 @@ filetype indent on
 " Specific filetype settings
 autocmd Filetype bash setlocal ts=4 sw=4 expandtab
 autocmd Filetype sh setlocal ts=4 sw=4 expandtab
+autocmd Filetype yaml setlocal ts=2 sw=2 expandtab
 
 " Use UTF-8 encoding
 set encoding=utf8
@@ -206,6 +207,10 @@ set ffs=unix,dos,mac
 
 " Enable syntax highlighting
 syntax enable
+
+let g:ansible_attribute_highlight = "ab"
+let g:ansible_name_highlight = 'd'
+let g:ansible_extra_keywords_highlight = 1
 
 " Configure colors for a dark background
 set background=dark


### PR DESCRIPTION
Updates included:
* Fix typo in vimrc
* Add new ansible and Yaml related setting to vimrc
* Use git and a symbolic link for pathogen installation
* Fix use of '~' in install.sh to match use of "$HOME"

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>